### PR TITLE
Fix for removing scheduler slowness due to sync call

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/remotetask/HttpRemoteTask.java
+++ b/core/trino-main/src/main/java/io/trino/server/remotetask/HttpRemoteTask.java
@@ -578,7 +578,7 @@ public final class HttpRemoteTask
     {
         // synchronized so that needsUpdate is not cleared in sendUpdate before actual request is sent
         needsUpdate.set(true);
-        sendUpdate();
+        scheduleUpdate();
     }
 
     private synchronized void sendUpdate()


### PR DESCRIPTION
This change will run taskupdate in a separate thread and will not synchronize the call causing scheduler slowness.
Fixes bug introduced by https://github.com/trinodb/trino/commit/613bd2f3feb42cc4aedf637260a2bc6672f323d4